### PR TITLE
Fix: Ses failure because commons-logging was excluded when compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,6 @@ configurations.all {
         force "org.apache.httpcomponents:httpclient:4.5.10" // resolve for awssdk:ses
         force "org.apache.httpcomponents:httpcore:4.4.12" // resolve for awssdk:ses
     }
-    // conflict with spring-jcl
-    exclude group: "commons-logging", module: "commons-logging"
 }
 
 dependencies {
@@ -119,7 +117,7 @@ dependencies {
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testCompile "org.mockito:mockito-core:2.23.0"
     testCompile 'com.google.code.gson:gson:2.8.6'
-    testCompile 'org.springframework.integration:spring-integration-mail:5.2.5.RELEASE'
+    testImplementation 'org.springframework.integration:spring-integration-mail:5.2.5.RELEASE'
     testImplementation 'org.springframework.integration:spring-integration-test-support:5.2.5.RELEASE'
 
     ktlint "com.pinterest:ktlint:0.33.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Revoked the exclusion of commons-logging dependency and replace compile spring jcl with `testImplementation`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
